### PR TITLE
Finalize FastAPI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This repository contains a minimal FastAPI application. The project is intended 
    uvicorn app.main:app --reload
    ```
    The service will be available at `http://127.0.0.1:8000`.
+3. Alternatively start the app directly:
+   ```bash
+   python app/main.py
+   ```
 
 ## Configuration
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,13 @@
 from fastapi import FastAPI
 from app.routers import pid
 
-app = FastAPI(
+
+app = FastAPI()
+
+app.include_router(pid.router)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/app/routers/pid.py
+++ b/app/routers/pid.py
@@ -1,5 +1,10 @@
 from fastapi import APIRouter
-from app.schemas.pid import PipingSystem, HandlelisteResponse
-from app.services.generator import generate_handleliste
 
-router = APIRouter(
+
+router = APIRouter()
+
+
+@router.get("/ping")
+async def ping() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- complete `FastAPI()` initialization and register the PID router
- add a simple `/ping` endpoint
- document how to run the API with `python app/main.py`
- provide a small entrypoint for running via uvicorn directly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68540e758cd8832199957db88db88f9e