### PR TITLE
Add pytest tests and finalize router

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ This repository contains a minimal FastAPI application. The project is intended 
 
 The project currently requires no environment variables, but a `.env` file can be placed in the repository root if you need to define settings for future features. Environment variables in this file will be loaded automatically if you integrate a tool such as `python-dotenv`.
 
+
+## Testing
+
+After installing the project dependencies, run the test suite with `pytest`:
+
+```bash
+pytest
+```
+
+This will execute the tests under the `tests/` directory and report any failures.

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
 from app.routers import pid
 
-app = FastAPI(
+app = FastAPI()
+app.include_router(pid.router)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,1 @@
+from . import pid

--- a/app/routers/pid.py
+++ b/app/routers/pid.py
@@ -2,4 +2,9 @@ from fastapi import APIRouter
 from app.schemas.pid import PipingSystem, HandlelisteResponse
 from app.services.generator import generate_handleliste
 
-router = APIRouter(
+router = APIRouter(prefix="/pid", tags=["pid"])
+
+@router.post("/handleliste", response_model=HandlelisteResponse)
+async def handleliste(system: PipingSystem) -> HandlelisteResponse:
+    """Generate a handleliste for the provided piping system."""
+    return generate_handleliste(system)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ python-dotenv
 
 # Offline LLM integration
 ollama
+httpx

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,11 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_handleliste_endpoint():
+    client = TestClient(app)
+    payload = {"components": ["pump", "flange"]}
+    response = client.post("/pid/handleliste", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"items": ["pump", "flange"]}

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,10 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.schemas.pid import PipingSystem, HandlelisteResponse
+from app.services.generator import generate_handleliste
+
+
+def test_generate_handleliste():
+    system = PipingSystem(components=["pipe", "valve"])
+    response = generate_handleliste(system)
+    assert isinstance(response, HandlelisteResponse)
+    assert response.items == ["pipe", "valve"]


### PR DESCRIPTION
## Summary
- finalize `main.py` and `pid` router so the API works
- add `__init__` modules for package imports
- include simple tests for the generator service and router endpoint
- document running tests in the README
- add `httpx` to requirements for `TestClient`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pytest -q tests/test_generator.py::test_generate_handleliste -s`

------
https://chatgpt.com/codex/tasks/task_b_68540f293ca083218c7bb3d29d37f7ba