### PR TITLE
Enhance handleliste generator logic

### DIFF
--- a/app/routers/pid.py
+++ b/app/routers/pid.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from app.schemas.pid import PipingSystem, HandlelisteResponse
 from app.services.generator import generate_handleliste
 
@@ -7,4 +7,7 @@ router = APIRouter(prefix="/pid", tags=["pid"])
 @router.post("/handleliste", response_model=HandlelisteResponse)
 async def handleliste(system: PipingSystem) -> HandlelisteResponse:
     """Generate a handleliste for the provided piping system."""
-    return generate_handleliste(system)
+    try:
+        return generate_handleliste(system)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/app/services/generator.py
+++ b/app/services/generator.py
@@ -1,6 +1,38 @@
 from app.schemas.pid import PipingSystem, HandlelisteResponse
 
 
+CATALOG = {
+    "pipe": "Pipe Item",
+    "valve": "Valve Item",
+    "pump": "Pump Item",
+    "flange": "Flange Item",
+}
+
+TRANSITIONS = {
+    "pipe": ["valve", "flange"],
+    "valve": ["pump"],
+    "pump": ["flange"],
+    "flange": ["pipe"],
+}
+
+
 def generate_handleliste(system: PipingSystem) -> HandlelisteResponse:
     """Generate a handleliste for the given piping system."""
-    return HandlelisteResponse(items=system.components)
+
+    items = []
+    previous = None
+    for component in system.components:
+        if component not in CATALOG:
+            raise ValueError(f"Unknown component: {component}")
+
+        if previous is not None:
+            allowed = TRANSITIONS.get(previous, [])
+            if component not in allowed:
+                raise ValueError(
+                    f"Invalid transition from {previous} to {component}"
+                )
+
+        items.append(CATALOG[component])
+        previous = component
+
+    return HandlelisteResponse(items=items)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -3,9 +3,25 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
-def test_handleliste_endpoint():
-    client = TestClient(app)
-    payload = {"components": ["pump", "flange"]}
+client = TestClient(app)
+
+
+def test_handleliste_endpoint_valid():
+    payload = {"components": ["pipe", "valve", "pump", "flange"]}
     response = client.post("/pid/handleliste", json=payload)
     assert response.status_code == 200
-    assert response.json() == {"items": ["pump", "flange"]}
+    assert response.json() == {
+        "items": ["Pipe Item", "Valve Item", "Pump Item", "Flange Item"]
+    }
+
+
+def test_handleliste_endpoint_invalid_component():
+    payload = {"components": ["pipe", "unknown"]}
+    response = client.post("/pid/handleliste", json=payload)
+    assert response.status_code == 400
+
+
+def test_handleliste_endpoint_invalid_transition():
+    payload = {"components": ["pump", "pipe"]}
+    response = client.post("/pid/handleliste", json=payload)
+    assert response.status_code == 400

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,10 +1,29 @@
 import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+
 from app.schemas.pid import PipingSystem, HandlelisteResponse
 from app.services.generator import generate_handleliste
 
 
-def test_generate_handleliste():
-    system = PipingSystem(components=["pipe", "valve"])
+def test_generate_handleliste_valid():
+    system = PipingSystem(components=["pipe", "valve", "pump", "flange"])
     response = generate_handleliste(system)
     assert isinstance(response, HandlelisteResponse)
-    assert response.items == ["pipe", "valve"]
+    assert response.items == [
+        "Pipe Item",
+        "Valve Item",
+        "Pump Item",
+        "Flange Item",
+    ]
+
+
+def test_generate_handleliste_invalid_component():
+    system = PipingSystem(components=["pipe", "unknown"])
+    with pytest.raises(ValueError):
+        generate_handleliste(system)
+
+
+def test_generate_handleliste_invalid_transition():
+    system = PipingSystem(components=["pump", "pipe"])
+    with pytest.raises(ValueError):
+        generate_handleliste(system)


### PR DESCRIPTION
## Summary
- implement catalog lookup and transition validation for `generate_handleliste`
- convert validation errors into HTTP 400 responses
- expand unit tests for generator and endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_685410cf29b8832187f3b7e4a2f4dfbd