### PR TITLE
Clean up dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .env
+venv/

--- a/README.md
+++ b/README.md
@@ -8,10 +8,7 @@ This repository contains a minimal FastAPI application. The project is intended 
    ```bash
    pip install -r requirements.txt
    ```
-   The file now includes packages for working with databases
-   (`SQLAlchemy`, `psycopg2-binary`), generating CSV/Excel files
-   (`pandas`, `openpyxl`), creating PDF reports (`reportlab`), and
-   interfacing with offline models via `ollama`.
+   This project only requires `fastapi`, `uvicorn`, `pydantic`, and `httpx`.
 2. Run the application using uvicorn:
    ```bash
    uvicorn app.main:app --reload
@@ -20,7 +17,7 @@ This repository contains a minimal FastAPI application. The project is intended 
 
 ## Configuration
 
-The project currently requires no environment variables, but a `.env` file can be placed in the repository root if you need to define settings for future features. Environment variables in this file will be loaded automatically if you integrate a tool such as `python-dotenv`.
+The project currently requires no environment variables, but you can add a `.env` file to configure future features as needed.
 
 
 ## Testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,4 @@
 fastapi
 uvicorn
 pydantic
-# Database libraries
-SQLAlchemy
-psycopg2-binary
-
-# CSV/Excel handling
-pandas
-openpyxl
-
-# PDF generation
-reportlab
-
-# File uploads and environment loading
-python-multipart
-python-dotenv
-
-# Offline LLM integration
-ollama
 httpx


### PR DESCRIPTION
## Summary
- clean up unneeded packages from `requirements.txt`
- document the reduced dependency list
- ignore the `venv/` directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68544cb34b248321bddd9bd1feb24d3c