### PR TITLE
Use enums for piping components

### DIFF
--- a/app/schemas/pid.py
+++ b/app/schemas/pid.py
@@ -1,10 +1,24 @@
+from __future__ import annotations
+
+from enum import Enum
 from typing import List
 from pydantic import BaseModel
 
+
+class Component(str, Enum):
+    """Valid components allowed in a ``PipingSystem``."""
+
+    PIPE = "pipe"
+    VALVE = "valve"
+    PUMP = "pump"
+    FLANGE = "flange"
+
 class PipingSystem(BaseModel):
     """Simple representation of a piping system."""
-    components: List[str]
+
+    components: List[Component]
 
 class HandlelisteResponse(BaseModel):
     """Response model for handleliste generation."""
+
     items: List[str]

--- a/app/services/generator.py
+++ b/app/services/generator.py
@@ -1,35 +1,38 @@
-from app.schemas.pid import PipingSystem, HandlelisteResponse
+from __future__ import annotations
+
+from app.schemas.pid import Component, PipingSystem, HandlelisteResponse
 
 
 CATALOG = {
-    "pipe": "Pipe Item",
-    "valve": "Valve Item",
-    "pump": "Pump Item",
-    "flange": "Flange Item",
+    Component.PIPE: "Pipe Item",
+    Component.VALVE: "Valve Item",
+    Component.PUMP: "Pump Item",
+    Component.FLANGE: "Flange Item",
 }
 
 TRANSITIONS = {
-    "pipe": ["valve", "flange"],
-    "valve": ["pump"],
-    "pump": ["flange"],
-    "flange": ["pipe"],
+    Component.PIPE: {Component.VALVE, Component.FLANGE},
+    Component.VALVE: {Component.PUMP},
+    Component.PUMP: {Component.FLANGE},
+    Component.FLANGE: {Component.PIPE},
 }
 
 
 def generate_handleliste(system: PipingSystem) -> HandlelisteResponse:
     """Generate a handleliste for the given piping system."""
 
-    items = []
-    previous = None
+    items: list[str] = []
+    previous: Component | None = None
+
     for component in system.components:
         if component not in CATALOG:
-            raise ValueError(f"Unknown component: {component}")
+            raise ValueError(f"Unknown component: {component.value}")
 
         if previous is not None:
-            allowed = TRANSITIONS.get(previous, [])
+            allowed = TRANSITIONS.get(previous, set())
             if component not in allowed:
                 raise ValueError(
-                    f"Invalid transition from {previous} to {component}"
+                    f"Invalid transition from {previous.value} to {component.value}"
                 )
 
         items.append(CATALOG[component])


### PR DESCRIPTION
## Summary
- introduce `Component` enum to define allowed piping parts
- update generator to use enums and sets for faster checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_685452de1cac8321a7f919896e7c1fb8