### PR TITLE
Add root endpoint and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This repository contains a minimal FastAPI application. The project is intended 
    uvicorn app.main:app --reload
    ```
    The service will be available at `http://127.0.0.1:8000`.
+   Visiting the root URL returns a simple welcome message, and the interactive
+   API docs are available at `http://127.0.0.1:8000/docs`.
 
 ## Configuration
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,4 +2,12 @@ from fastapi import FastAPI
 from app.routers import pid
 
 app = FastAPI()
+
+
+@app.get("/")
+async def read_root() -> dict[str, str]:
+    """Simple welcome endpoint for the root path."""
+    return {"message": "Welcome to the Jobb FastAPI Example"}
+
+
 app.include_router(pid.router)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -6,6 +6,12 @@ from app.main import app
 client = TestClient(app)
 
 
+def test_root_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Welcome to the Jobb FastAPI Example"}
+
+
 def test_handleliste_endpoint_valid():
     payload = {"components": ["pipe", "valve", "pump", "flange"]}
     response = client.post("/pid/handleliste", json=payload)
@@ -18,7 +24,9 @@ def test_handleliste_endpoint_valid():
 def test_handleliste_endpoint_invalid_component():
     payload = {"components": ["pipe", "unknown"]}
     response = client.post("/pid/handleliste", json=payload)
-    assert response.status_code == 400
+    # Pydantic validation fails before hitting the endpoint, resulting in a
+    # 422 response from FastAPI.
+    assert response.status_code == 422
 
 
 def test_handleliste_endpoint_invalid_transition():

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,5 +1,6 @@
 import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import pytest
+from pydantic import ValidationError
 
 from app.schemas.pid import PipingSystem, HandlelisteResponse
 from app.services.generator import generate_handleliste
@@ -18,9 +19,8 @@ def test_generate_handleliste_valid():
 
 
 def test_generate_handleliste_invalid_component():
-    system = PipingSystem(components=["pipe", "unknown"])
-    with pytest.raises(ValueError):
-        generate_handleliste(system)
+    with pytest.raises(ValidationError):
+        generate_handleliste(PipingSystem(components=["pipe", "unknown"]))
 
 
 def test_generate_handleliste_invalid_transition():


### PR DESCRIPTION
## Summary
- add a welcome message for GET /
- document the new root endpoint in README
- update tests for new validation behaviour

## Testing
- `PYTHONPATH=venv/lib/python3.11/site-packages pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68545a3c00d883218a7b1ff957ad77c7