### PR TITLE
Enhance P&ID frontend with drag-and-drop and automatic fittings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ This repository contains a minimal FastAPI application. The project is intended 
    uvicorn app.main:app --reload
    ```
    The service will be available at `http://127.0.0.1:8000`.
-   Visiting the root URL returns a simple welcome message, and the interactive
-   API docs are available at `http://127.0.0.1:8000/docs`.
+Visiting the root URL now launches a Smart P&ID designer where you can drag
+valves, pumps, filters and analysers onto a canvas and draw lines between
+them. The application automatically inserts Parker tees when lines intersect,
+adds bulkheads when a line enters or exits the dashed frame, and suggests
+adapters if line sizes differ. The previous API welcome message has moved to
+`http://127.0.0.1:8000/api`. The interactive API docs are still available at
+`http://127.0.0.1:8000/docs`.
 
 ## Configuration
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,26 @@
+from pathlib import Path
+
 from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
 from app.routers import pid
 
 app = FastAPI()
 
+static_dir = Path(__file__).resolve().parent / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
 
 @app.get("/")
+async def frontend() -> FileResponse:
+    """Serve the HTML frontend for the application."""
+    return FileResponse(static_dir / "index.html")
+
+
+@app.get("/api")
 async def read_root() -> dict[str, str]:
-    """Simple welcome endpoint for the root path."""
+    """Simple welcome endpoint for the API root path."""
     return {"message": "Welcome to the Jobb FastAPI Example"}
 
 

--- a/app/schemas/pid.py
+++ b/app/schemas/pid.py
@@ -12,11 +12,24 @@ class Component(str, Enum):
     VALVE = "valve"
     PUMP = "pump"
     FLANGE = "flange"
+    FILTER = "filter"
+    ANALYZER = "analyzer"
+
+
+class Line(BaseModel):
+    """Connection between two components."""
+
+    start: int
+    end: int
+    size: str
+    tee: bool = False
+    bulkhead: bool = False
 
 class PipingSystem(BaseModel):
     """Simple representation of a piping system."""
 
     components: List[Component]
+    lines: List[Line] = []
 
 class HandlelisteResponse(BaseModel):
     """Response model for handleliste generation."""

--- a/app/services/generator.py
+++ b/app/services/generator.py
@@ -8,13 +8,27 @@ CATALOG = {
     Component.VALVE: "Valve Item",
     Component.PUMP: "Pump Item",
     Component.FLANGE: "Flange Item",
+    Component.FILTER: "Filter Item",
+    Component.ANALYZER: "Analyzer Item",
+}
+
+FITTINGS = {
+    (Component.PIPE, Component.VALVE): "Parker Coupling",
+    (Component.VALVE, Component.PUMP): "Parker Adapter",
+    (Component.PUMP, Component.FLANGE): "Parker Connector",
+    (Component.FLANGE, Component.PIPE): "Parker Gasket",
+    (Component.PIPE, Component.FILTER): "Parker Coupling",
+    (Component.FILTER, Component.ANALYZER): "Parker Connector",
+    (Component.ANALYZER, Component.FLANGE): "Parker Adapter",
 }
 
 TRANSITIONS = {
-    Component.PIPE: {Component.VALVE, Component.FLANGE},
-    Component.VALVE: {Component.PUMP},
+    Component.PIPE: {Component.VALVE, Component.FLANGE, Component.FILTER},
+    Component.VALVE: {Component.PUMP, Component.FILTER},
     Component.PUMP: {Component.FLANGE},
     Component.FLANGE: {Component.PIPE},
+    Component.FILTER: {Component.ANALYZER},
+    Component.ANALYZER: {Component.FLANGE},
 }
 
 
@@ -22,20 +36,57 @@ def generate_handleliste(system: PipingSystem) -> HandlelisteResponse:
     """Generate a handleliste for the given piping system."""
 
     items: list[str] = []
-    previous: Component | None = None
 
-    for component in system.components:
-        if component not in CATALOG:
-            raise ValueError(f"Unknown component: {component.value}")
+    for comp in system.components:
+        if comp not in CATALOG:
+            raise ValueError(f"Unknown component: {comp.value}")
 
-        if previous is not None:
-            allowed = TRANSITIONS.get(previous, set())
-            if component not in allowed:
-                raise ValueError(
-                    f"Invalid transition from {previous.value} to {component.value}"
-                )
+    seen: set[int] = set()
+    connection_sizes: dict[int, str] = {}
 
-        items.append(CATALOG[component])
-        previous = component
+    for idx, line in enumerate(system.lines):
+        try:
+            start_comp = system.components[line.start]
+            end_comp = system.components[line.end]
+        except IndexError as exc:
+            raise ValueError("Line references invalid component index") from exc
+
+        # add start component if not added yet
+        if line.start not in seen:
+            items.append(CATALOG[start_comp])
+            seen.add(line.start)
+
+        # check transition validity
+        allowed = TRANSITIONS.get(start_comp, set())
+        if end_comp not in allowed:
+            raise ValueError(
+                f"Invalid transition from {start_comp.value} to {end_comp.value}"
+            )
+
+        # adapter if component already connected with different size
+        prev_size = connection_sizes.get(line.start)
+        if prev_size is not None and prev_size != line.size:
+            items.append("Parker Adapter")
+
+        fitting = FITTINGS.get((start_comp, end_comp))
+        if fitting:
+            items.append(fitting)
+
+        if line.bulkhead:
+            items.append("Parker Bulkhead")
+        if line.tee:
+            items.append("Parker Tee")
+
+        connection_sizes[line.start] = line.size
+        connection_sizes[line.end] = line.size
+
+        if line.end not in seen:
+            items.append(CATALOG[end_comp])
+            seen.add(line.end)
+
+    # include standalone components with no lines
+    for idx, comp in enumerate(system.components):
+        if idx not in seen:
+            items.append(CATALOG[comp])
 
     return HandlelisteResponse(items=items)

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Smart P&ID Designer</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 1rem; }
+        #toolbar { margin-bottom: 1rem; }
+        #palette button { margin-right: .5rem; }
+        #canvas { position: relative; border: 1px solid #ccc; width: 800px; height: 400px; overflow: hidden; }
+        .node { position: absolute; padding: .3rem .6rem; background: #e3e3e3; border: 1px solid #000; cursor: move; user-select: none; }
+        svg { position: absolute; left: 0; top: 0; width: 800px; height: 400px; pointer-events: none; }
+        #frame { position:absolute; left:500px; top:50px; width:250px; height:250px; border:2px dashed #999; pointer-events:none; }
+    </style>
+</head>
+<body>
+<h1>Smart P&ID Designer</h1>
+<div id="toolbar">
+    <div id="palette">
+        <button data-type="valve">Valve</button>
+        <button data-type="pump">Pump</button>
+        <button data-type="filter">Filter</button>
+        <button data-type="analyzer">Analyzer</button>
+    </div>
+    <label for="size">Line size:</label>
+    <select id="size">
+        <option value="1\"">1"</option>
+        <option value="3/8\"">3/8"</option>
+        <option value="6mm">6 mm</option>
+    </select>
+    <button id="export">Generate Handleliste</button>
+</div>
+<div id="canvas">
+    <svg id="lines"></svg>
+    <div id="frame"></div>
+</div>
+<pre id="output"></pre>
+<script>
+const components = [];
+const lines = [];
+let idCounter = 0;
+let drawing = null;
+
+function createNode(type, x=10, y=10) {
+    const node = document.createElement('div');
+    node.className = 'node';
+    node.textContent = type;
+    node.style.left = x + 'px';
+    node.style.top = y + 'px';
+    node.dataset.id = idCounter;
+    node.dataset.type = type;
+    makeDraggable(node);
+    document.getElementById('canvas').appendChild(node);
+    components.push({id:idCounter, type, x, y});
+    idCounter++;
+}
+
+function makeDraggable(el) {
+    el.addEventListener('mousedown', e => {
+        const offsetX = e.clientX - el.offsetLeft;
+        const offsetY = e.clientY - el.offsetTop;
+        function onMove(ev) {
+            el.style.left = ev.clientX - offsetX + 'px';
+            el.style.top = ev.clientY - offsetY + 'px';
+            const c = components.find(c => c.id == el.dataset.id);
+            c.x = el.offsetLeft;
+            c.y = el.offsetTop;
+            drawAllLines();
+        }
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', () => {
+            document.removeEventListener('mousemove', onMove);
+        }, {once:true});
+    });
+}
+
+function startLine(fromNode) {
+    drawing = {start: parseInt(fromNode.dataset.id), x1: fromNode.offsetLeft+30, y1: fromNode.offsetTop+15};
+}
+
+function finishLine(toNode) {
+    if (!drawing) return;
+    drawing.end = parseInt(toNode.dataset.id);
+    drawing.x2 = toNode.offsetLeft+30;
+    drawing.y2 = toNode.offsetTop+15;
+    drawing.size = document.getElementById('size').value;
+    drawing.tee = false;
+    drawing.bulkhead = false;
+    lines.push(drawing);
+    drawing = null;
+    drawAllLines();
+}
+
+function lineIntersects(l1, l2) {
+    function ccw(ax,ay,bx,by,cx,cy){ return (cy-ay)*(bx-ax) > (by-ay)*(cx-ax); }
+    return ccw(l1.x1,l1.y1,l2.x1,l2.y1,l2.x2,l2.y2) !== ccw(l1.x2,l1.y2,l2.x1,l2.y1,l2.x2,l2.y2) &&
+           ccw(l1.x1,l1.y1,l1.x2,l1.y2,l2.x1,l2.y1) !== ccw(l1.x1,l1.y1,l1.x2,l1.y2,l2.x2,l2.y2);
+}
+
+function pointInsideRect(x,y,rect){ return x>rect.left && x<rect.right && y>rect.top && y<rect.bottom; }
+
+function drawAllLines() {
+    const svg = document.getElementById('lines');
+    svg.innerHTML = '';
+    // reset tee/bulkhead flags
+    lines.forEach(l => {l.tee=false; l.bulkhead=false;});
+    for (let i=0;i<lines.length;i++) {
+        const l = lines[i];
+        const start = components.find(c=>c.id===l.start);
+        const end = components.find(c=>c.id===l.end);
+        l.x1 = start.x+30; l.y1 = start.y+15;
+        l.x2 = end.x+30; l.y2 = end.y+15;
+        const frameRect = document.getElementById('frame').getBoundingClientRect();
+        const inStart = pointInsideRect(l.x1,l.y1,frameRect);
+        const inEnd = pointInsideRect(l.x2,l.y2,frameRect);
+        if (inStart !== inEnd) l.bulkhead = true;
+        for (let j=0;j<i;j++) {
+            if (lineIntersects(l, lines[j])) {
+                l.tee = true;
+                break;
+            }
+        }
+        const lineEl = document.createElementNS('http://www.w3.org/2000/svg','line');
+        lineEl.setAttribute('x1', l.x1);
+        lineEl.setAttribute('y1', l.y1);
+        lineEl.setAttribute('x2', l.x2);
+        lineEl.setAttribute('y2', l.y2);
+        lineEl.setAttribute('stroke','black');
+        lineEl.setAttribute('stroke-width','2');
+        svg.appendChild(lineEl);
+    }
+}
+
+document.getElementById('palette').addEventListener('click', e => {
+    if (e.target.tagName === 'BUTTON') {
+        createNode(e.target.dataset.type, 20 + components.length*60, 20);
+    }
+});
+
+const canvas = document.getElementById('canvas');
+canvas.addEventListener('click', e => {
+    const node = e.target.closest('.node');
+    if (node) {
+        if (!drawing) {
+            startLine(node);
+        } else {
+            finishLine(node);
+        }
+    }
+});
+
+function buildPayload() {
+    return {
+        components: components.map(c => c.type),
+        lines: lines.map(l => ({start:l.start, end:l.end, size:l.size, tee:l.tee, bulkhead:l.bulkhead}))
+    };
+}
+
+document.getElementById('export').addEventListener('click', async () => {
+    const output = document.getElementById('output');
+    output.textContent = 'Loading...';
+    try {
+        const response = await fetch('/pid/handleliste', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify(buildPayload())
+        });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data.detail || 'Error');
+        output.textContent = data.items.join('\n');
+    } catch (err) {
+        output.textContent = err.message;
+    }
+});
+</script>
+</body>
+</html>

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -7,23 +7,49 @@ from app.services.generator import generate_handleliste
 
 
 def test_generate_handleliste_valid():
-    system = PipingSystem(components=["pipe", "valve", "pump", "flange"])
+    system = PipingSystem(
+        components=["pipe", "valve", "pump", "flange"],
+        lines=[
+            {"start": 0, "end": 1, "size": "1\""},
+            {"start": 1, "end": 2, "size": "1\""},
+            {"start": 2, "end": 3, "size": "1\""},
+        ],
+    )
     response = generate_handleliste(system)
     assert isinstance(response, HandlelisteResponse)
     assert response.items == [
         "Pipe Item",
+        "Parker Coupling",
         "Valve Item",
+        "Parker Adapter",
         "Pump Item",
+        "Parker Connector",
         "Flange Item",
     ]
 
 
 def test_generate_handleliste_invalid_component():
     with pytest.raises(ValidationError):
-        generate_handleliste(PipingSystem(components=["pipe", "unknown"]))
+        generate_handleliste(PipingSystem(components=["pipe", "unknown"], lines=[]))
 
 
 def test_generate_handleliste_invalid_transition():
-    system = PipingSystem(components=["pump", "pipe"])
+    system = PipingSystem(
+        components=["pump", "pipe"],
+        lines=[{"start": 0, "end": 1, "size": "1\""}],
+    )
     with pytest.raises(ValueError):
         generate_handleliste(system)
+
+
+def test_generate_handleliste_with_line_features():
+    system = PipingSystem(
+        components=["pipe", "valve", "pump"],
+        lines=[
+            {"start": 0, "end": 1, "size": "1\"", "bulkhead": True},
+            {"start": 1, "end": 2, "size": "3/8\""},
+        ],
+    )
+    response = generate_handleliste(system)
+    assert "Parker Bulkhead" in response.items
+    assert "Parker Adapter" in response.items


### PR DESCRIPTION
## Summary
- extend data model with Line objects and new components
- generate Parker tees, bulkheads and adapters automatically
- overhaul the HTML frontend to support drag & drop drawing with line size selection
- update documentation and tests for the new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68545fb5bb4c832199956f2a9dd30523