### PR TITLE
Implement fittings storage and new endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
-from app.routers import pid, pdf
+from app.routers import pid, pdf, fittings
 
 app = FastAPI()
 
@@ -26,3 +26,4 @@ async def read_root() -> dict[str, str]:
 
 app.include_router(pid.router)
 app.include_router(pdf.router)
+app.include_router(fittings.router)

--- a/app/routers/fittings.py
+++ b/app/routers/fittings.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.fittings import Fitting
+from app.services.fittings_store import get_fitting, add_fitting
+
+router = APIRouter(prefix="/fittings", tags=["fittings"])
+
+
+@router.get("/{code}", response_model=Fitting)
+async def read_fitting(code: str) -> Fitting:
+    """Retrieve information about a fitting by its code."""
+    fitting = get_fitting(code)
+    if not fitting:
+        raise HTTPException(status_code=404, detail="Fitting not found")
+    return fitting
+
+
+@router.post("/", status_code=201, response_model=Fitting)
+async def create_fitting(fitting: Fitting) -> Fitting:
+    """Add a new fitting to the store."""
+    add_fitting(fitting)
+    return fitting

--- a/app/schemas/fittings.py
+++ b/app/schemas/fittings.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class Fitting(BaseModel):
+    """Description of an instrumentation fitting."""
+
+    code: str
+    description: str
+    series: str
+    configuration: str
+    cracking_pressure: str | None = None
+    material: str | None = None

--- a/app/services/fittings_store.py
+++ b/app/services/fittings_store.py
@@ -1,0 +1,28 @@
+"""Simple in-memory store for instrumentation fittings."""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from app.schemas.fittings import Fitting
+
+
+_FITTINGS: Dict[str, Fitting] = {
+    "4A-C4L-25-SS": Fitting(
+        code="4A-C4L-25-SS",
+        description="Check valve",
+        series="4A",
+        configuration="C4L",
+        cracking_pressure="25 psi",
+        material="stainless steel",
+    )
+}
+
+
+def get_fitting(code: str) -> Optional[Fitting]:
+    """Return fitting information for the given code."""
+    return _FITTINGS.get(code)
+
+
+def add_fitting(fitting: Fitting) -> None:
+    """Add or update a fitting in the store."""
+    _FITTINGS[fitting.code] = fitting

--- a/tests/test_fittings.py
+++ b/tests/test_fittings.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from app.schemas.fittings import Fitting
+from app.services.fittings_store import get_fitting, add_fitting
+from app.routers.fittings import read_fitting, create_fitting
+
+
+def test_get_fitting_default():
+    fitting = get_fitting("4A-C4L-25-SS")
+    assert fitting
+    assert fitting.description == "Check valve"
+
+
+def test_add_and_get_fitting_service():
+    fit = Fitting(
+        code="2B-XYZ-10-CS",
+        description="Sample valve",
+        series="2B",
+        configuration="XYZ",
+        cracking_pressure="10 psi",
+        material="carbon steel",
+    )
+    add_fitting(fit)
+    retrieved = get_fitting("2B-XYZ-10-CS")
+    assert retrieved and retrieved.material == "carbon steel"
+
+
+def test_fitting_endpoints():
+    new_fit = Fitting(
+        code="1A-TEST-5-SS",
+        description="Dummy",
+        series="1A",
+        configuration="TEST",
+        cracking_pressure="5 psi",
+        material="stainless steel",
+    )
+    created = asyncio.run(create_fitting(new_fit))
+    assert created.code == new_fit.code
+    fetched = asyncio.run(read_fitting("1A-TEST-5-SS"))
+    assert fetched.configuration == "TEST"


### PR DESCRIPTION
## Summary
- store instrumentation fittings with pydantic schema
- expose `/fittings` API for retrieving and adding fittings
- register new router
- test fittings storage and router endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68553fac046883218379b92424d06e12