### PR TITLE
Add portal for PDF uploads

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,12 @@ async def frontend() -> FileResponse:
     return FileResponse(static_dir / "index.html")
 
 
+@app.get("/upload")
+async def upload_portal() -> FileResponse:
+    """Serve the PDF upload portal."""
+    return FileResponse(static_dir / "upload.html")
+
+
 @app.get("/api")
 async def read_root() -> dict[str, str]:
     """Simple welcome endpoint for the API root path."""

--- a/app/routers/pdf.py
+++ b/app/routers/pdf.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Body
 from pathlib import Path
 
-from app.services.pdf_reader import read_pdf_text
+from app.services.pdf_reader import read_pdf_text, read_pdf_bytes
 
 router = APIRouter(prefix="/pdf", tags=["pdf"])
 
@@ -14,4 +14,11 @@ async def read_pdf(path: str) -> dict[str, str]:
         raise HTTPException(status_code=404, detail="File not found")
 
     text = read_pdf_text(pdf_path)
+    return {"text": text}
+
+
+@router.post("/extract")
+async def extract_pdf(data: bytes = Body(...)) -> dict[str, str]:
+    """Extract and return text from uploaded PDF bytes."""
+    text = read_pdf_bytes(data)
     return {"text": text}

--- a/app/services/pdf_reader.py
+++ b/app/services/pdf_reader.py
@@ -3,15 +3,8 @@ import zlib
 from pathlib import Path
 
 
-def read_pdf_text(path: str | Path) -> str:
-    """Extract text from a PDF file.
-
-    This implementation only handles simple PDFs with optional Flate encoded
-    streams. It scans each stream section and tries to decompress it if
-    necessary, then collects text within parentheses.
-    """
-    pdf_path = Path(path)
-    data = pdf_path.read_bytes()
+def _extract_text(data: bytes) -> str:
+    """Extract text from raw PDF bytes."""
     text_parts: list[str] = []
 
     for match in re.finditer(rb"stream\r?\n(.*?)endstream", data, re.S):
@@ -28,4 +21,17 @@ def read_pdf_text(path: str | Path) -> str:
                 text_parts.append(section.decode("utf-8"))
             except UnicodeDecodeError:
                 text_parts.append(section.decode("latin1", errors="ignore"))
+
     return "".join(text_parts)
+
+
+def read_pdf_text(path: str | Path) -> str:
+    """Extract text from a PDF file given a path."""
+    pdf_path = Path(path)
+    data = pdf_path.read_bytes()
+    return _extract_text(data)
+
+
+def read_pdf_bytes(data: bytes) -> str:
+    """Extract text from an uploaded PDF file."""
+    return _extract_text(data)

--- a/app/static/upload.html
+++ b/app/static/upload.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>PDF Upload Portal</title>
+</head>
+<body>
+<h1>Upload PDF</h1>
+<form id="upload-form">
+    <input type="file" id="pdf" accept="application/pdf" required>
+    <button type="submit">Upload</button>
+</form>
+<pre id="output"></pre>
+<script>
+document.getElementById('upload-form').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const input = document.getElementById('pdf');
+    if (!input.files.length) return;
+    const file = input.files[0];
+    const resp = await fetch('/pdf/extract', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/pdf'},
+        body: file
+    });
+    const data = await resp.json();
+    document.getElementById('output').textContent = data.text || data.detail;
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement PDF text extraction from bytes
- add `/extract` PDF endpoint
- serve new `upload.html` portal under `/upload`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68556181bf888321993b9aec6b8c4791