### PR TITLE
Implement simple agent tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,18 @@ a canvas. When a new line branches off an existing one, the application
 automatically inserts a tee fitting. Projects can be saved to or loaded from
 JSON files.
 
+
+## Agent Tools
+
+The `app.services.agent_tools` module provides two simple utilities:
+
+- **DocumentMonitor**: watches a file for changes and runs an agent after the
+  file has not been edited for 10 seconds. A demo CLI is available:
+  ```bash
+  python -m app.services.document_monitor_cli path/to/file.txt
+  ```
+- **ChatAgent**: allows chatting with a simple agent that responds after the
+  user stops typing for 10 seconds. Start it with:
+  ```bash
+  python -m app.services.chat_cli
+  ```

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,13 @@
+from .agent_tools import DocumentMonitor, ChatAgent
+from .fittings_store import get_fitting, add_fitting
+from .generator import generate_handleliste
+from .pdf_reader import read_pdf_text
+
+__all__ = [
+    "DocumentMonitor",
+    "ChatAgent",
+    "get_fitting",
+    "add_fitting",
+    "generate_handleliste",
+    "read_pdf_text",
+]

--- a/app/services/agent_tools.py
+++ b/app/services/agent_tools.py
@@ -1,0 +1,75 @@
+import threading
+import time
+from pathlib import Path
+from typing import Callable, List, Tuple
+
+
+class DocumentMonitor:
+    """Monitor a file and trigger a callback after a period of inactivity."""
+
+    def __init__(self, path: str | Path, callback: Callable[[Path], None], delay: float = 10.0) -> None:
+        self.path = Path(path)
+        self.callback = callback
+        self.delay = delay
+        if self.path.exists():
+            stat = self.path.stat()
+            self._last_state: tuple[float, int] = (stat.st_mtime, stat.st_size)
+        else:
+            self._last_state = (None, 0)
+        self._timer: threading.Timer | None = None
+
+    def _on_idle(self) -> None:
+        self._timer = None
+        self.callback(self.path)
+
+    def check(self) -> None:
+        """Check the file for modifications and reset the idle timer."""
+        if self.path.exists():
+            stat = self.path.stat()
+            state = (stat.st_mtime, stat.st_size)
+        else:
+            state = (None, 0)
+        if state != self._last_state:
+            self._last_state = state
+            if self._timer:
+                self._timer.cancel()
+            self._timer = threading.Timer(self.delay, self._on_idle)
+            self._timer.start()
+
+    def start(self, poll_interval: float = 1.0) -> None:
+        """Continuously monitor the file until interrupted."""
+        try:
+            while True:
+                self.check()
+                time.sleep(poll_interval)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            if self._timer:
+                self._timer.cancel()
+
+
+class ChatAgent:
+    """Simple chat agent that responds after a period of inactivity."""
+
+    def __init__(self, response_fn: Callable[[str], str] | None = None, delay: float = 10.0) -> None:
+        self.response_fn = response_fn or (lambda msg: msg[::-1])
+        self.delay = delay
+        self.history: List[Tuple[str, str]] = []
+        self._timer: threading.Timer | None = None
+
+    def _respond(self) -> None:
+        if not self.history:
+            return
+        last_msg = self.history[-1][1]
+        reply = self.response_fn(last_msg)
+        self.history.append(("agent", reply))
+        print(f"Agent: {reply}")
+        self._timer = None
+
+    def user_message(self, message: str) -> None:
+        self.history.append(("user", message))
+        if self._timer:
+            self._timer.cancel()
+        self._timer = threading.Timer(self.delay, self._respond)
+        self._timer.start()

--- a/app/services/chat_cli.py
+++ b/app/services/chat_cli.py
@@ -1,0 +1,18 @@
+from .agent_tools import ChatAgent
+
+
+def main() -> None:
+    agent = ChatAgent()
+    print("Start chatting with the agent. Type 'exit' to quit.")
+    try:
+        while True:
+            msg = input("You: ")
+            if msg.lower() in {"exit", "quit"}:
+                break
+            agent.user_message(msg)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/app/services/document_monitor_cli.py
+++ b/app/services/document_monitor_cli.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+from .agent_tools import DocumentMonitor
+
+
+def process_file(path: Path) -> None:
+    try:
+        text = path.read_text()
+    except Exception as exc:
+        print(f"Could not read {path}: {exc}")
+        return
+    print(f"\nAgent processed {path} -> {len(text)} characters\n")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python -m app.services.document_monitor_cli <file>")
+        return
+    doc = Path(sys.argv[1])
+    monitor = DocumentMonitor(doc, process_file)
+    print(f"Monitoring {doc}. Stop editing for 10 seconds to trigger agent.")
+    monitor.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,0 +1,28 @@
+import os, sys; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import time
+from pathlib import Path
+from app.services.agent_tools import DocumentMonitor, ChatAgent
+
+
+def test_document_monitor_triggers(tmp_path):
+    doc = tmp_path / "file.txt"
+    doc.write_text("hello")
+    triggered = []
+
+    def callback(path: Path) -> None:
+        triggered.append(path.read_text())
+
+    monitor = DocumentMonitor(doc, callback, delay=0.1)
+    monitor.check()  # initial state
+    doc.write_text("changed")
+    monitor.check()
+    time.sleep(0.2)
+    assert triggered == ["changed"]
+
+
+def test_chat_agent_response():
+    outputs = []
+    agent = ChatAgent(response_fn=lambda msg: msg.upper(), delay=0.1)
+    agent.user_message("hi")
+    time.sleep(0.2)
+    assert agent.history[-1] == ("agent", "HI")


### PR DESCRIPTION
## Summary
- add `DocumentMonitor` and `ChatAgent` utilities
- create CLI demos for monitoring a document and chatting
- expose agent tools from the services package
- document the new features in README
- test the agent utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a9e37eb8c8321ad14140c0f3c97dc