### PR TITLE
Add interactivity to Dear PyGui canvas

### DIFF
--- a/app/tubing_gui.py
+++ b/app/tubing_gui.py
@@ -13,6 +13,83 @@ import math
 
 from dearpygui import dearpygui as dpg
 
+# ---------------------------------------------------------------------------
+# Interactivity helpers
+# ---------------------------------------------------------------------------
+
+selected_item: tuple[int, object] | None = None
+"""Currently selected draw tag and bound object."""
+
+interactable_items: dict[int, object] = {}
+"""Mapping of draw tags to their backing data objects."""
+
+
+def register_interactable(tag: int, obj: object) -> None:
+    """Register a draw item for interaction."""
+    interactable_items[tag] = obj
+
+
+def on_mouse_click(sender, app_data):
+    """Select an item or begin drawing a line."""
+    global selected_item
+    mouse_pos = dpg.get_mouse_pos(local=False)
+    for tag, obj in interactable_items.items():
+        pos = getattr(obj, "position", (0.0, 0.0))
+        if math.dist(mouse_pos, pos) <= 10:
+            selected_item = (tag, obj)
+            return
+
+    # If nothing selected, begin drawing a line
+    start_line(sender, app_data)
+
+
+def on_mouse_drag(sender, app_data):
+    """Move the selected item with the mouse."""
+    if not selected_item:
+        return
+
+    tag, obj = selected_item
+    new_pos = dpg.get_mouse_pos(local=False)
+    obj.position = new_pos
+
+    if isinstance(obj, Valve):
+        dpg.configure_item(tag, pmin=(new_pos[0] - 5, new_pos[1] - 5), pmax=(new_pos[0] + 5, new_pos[1] + 5))
+    elif isinstance(obj, Tee):
+        dpg.configure_item(tag, center=new_pos)
+    elif isinstance(obj, Analyzer):
+        dpg.configure_item(
+            tag,
+            p1=(new_pos[0], new_pos[1] - 5),
+            p2=(new_pos[0] - 5, new_pos[1] + 5),
+            p3=(new_pos[0] + 5, new_pos[1] + 5),
+        )
+
+
+def on_mouse_release(sender, app_data):
+    """Finish drawing or clear the selection on mouse release."""
+    global selected_item
+    if selected_item is None:
+        finish_line(sender, app_data)
+    selected_item = None
+
+
+def delete_selected_item() -> None:
+    """Delete the currently selected component from the canvas and project."""
+    if not selected_item:
+        return
+
+    tag, obj = selected_item
+    if isinstance(obj, Valve) and obj in PROJECT.valves:
+        PROJECT.valves.remove(obj)
+    elif isinstance(obj, Tee) and obj in PROJECT.tees:
+        PROJECT.tees.remove(obj)
+    elif isinstance(obj, Analyzer) and obj in PROJECT.analyzers:
+        PROJECT.analyzers.remove(obj)
+
+    dpg.delete_item(tag)
+    interactable_items.pop(tag, None)
+    selected_item = None
+
 
 class SystemType(Enum):
     """Supported tubing system types."""
@@ -200,20 +277,33 @@ def add_analyzer():
 
 def redraw_canvas():
     dpg.delete_item("drawlist", children_only=True)
+    interactable_items.clear()
     for line in PROJECT.tubings:
         dpg.draw_line(line.start, line.end, color=(200, 0, 0), thickness=2, parent="drawlist")
 
     for tee in PROJECT.tees:
-        dpg.draw_circle(tee.position, 5, color=(0, 0, 200), fill=(0, 0, 200), parent="drawlist")
+        tag = dpg.draw_circle(tee.position, 5, color=(0, 0, 200), fill=(0, 0, 200), parent="drawlist")
+        register_interactable(tag, tee)
 
     for valve in PROJECT.valves:
-        dpg.draw_rectangle((valve.position[0]-5, valve.position[1]-5), (valve.position[0]+5, valve.position[1]+5),
-                           color=(0, 200, 0), fill=(0, 200, 0), parent="drawlist")
+        tag = dpg.draw_rectangle(
+            (valve.position[0] - 5, valve.position[1] - 5),
+            (valve.position[0] + 5, valve.position[1] + 5),
+            color=(0, 200, 0),
+            fill=(0, 200, 0),
+            parent="drawlist",
+        )
+        register_interactable(tag, valve)
     for analyzer in PROJECT.analyzers:
-        dpg.draw_triangle((analyzer.position[0], analyzer.position[1]-5),
-                          (analyzer.position[0]-5, analyzer.position[1]+5),
-                          (analyzer.position[0]+5, analyzer.position[1]+5),
-                          color=(200, 200, 0), fill=(200, 200, 0), parent="drawlist")
+        tag = dpg.draw_triangle(
+            (analyzer.position[0], analyzer.position[1] - 5),
+            (analyzer.position[0] - 5, analyzer.position[1] + 5),
+            (analyzer.position[0] + 5, analyzer.position[1] + 5),
+            color=(200, 200, 0),
+            fill=(200, 200, 0),
+            parent="drawlist",
+        )
+        register_interactable(tag, analyzer)
 
 
 def main():
@@ -233,6 +323,7 @@ def main():
 
         dpg.add_button(label="Add Valve", callback=lambda: add_valve())
         dpg.add_button(label="Add Analyzer", callback=lambda: add_analyzer())
+        dpg.add_button(label="Delete Selected", callback=lambda: delete_selected_item())
         dpg.add_input_text(label="Save Path", tag="save_path")
         dpg.add_button(label="Save", callback=lambda: save_project())
         dpg.add_input_text(label="Load Path", tag="load_path")
@@ -243,8 +334,9 @@ def main():
             pass
 
     with dpg.handler_registry():
-        dpg.add_mouse_click_handler(button=dpg.mvMouseButton_Left, callback=start_line)
-        dpg.add_mouse_release_handler(button=dpg.mvMouseButton_Left, callback=finish_line)
+        dpg.add_mouse_click_handler(button=dpg.mvMouseButton_Left, callback=on_mouse_click)
+        dpg.add_mouse_drag_handler(button=dpg.mvMouseButton_Left, callback=on_mouse_drag)
+        dpg.add_mouse_release_handler(button=dpg.mvMouseButton_Left, callback=on_mouse_release)
 
 
     dpg.setup_dearpygui()


### PR DESCRIPTION
## Summary
- implement interactive item selection and movement
- register draw items for valve, tee and analyzer
- add control to delete selected items
- hook new mouse handlers for selection and drag support

## Testing
- `pytest -q` *(fails: FileResponse not defined)*

------
https://chatgpt.com/codex/tasks/task_b_685af7b3e97c83218ccf870ccc426a5e