### PR TITLE
Improve tubing design UI feedback

### DIFF
--- a/app/tubing_gui.py
+++ b/app/tubing_gui.py
@@ -9,6 +9,7 @@ import json
 from pathlib import Path
 
 import math
+import time
 
 
 from dearpygui import dearpygui as dpg
@@ -26,10 +27,15 @@ SELECTED_LINE: int | None = None
 ENDPOINT_MARKERS: list[int] = []
 MIDPOINT_MARKER: int | None = None
 
-# Line selection helpers
-SELECTED_LINE: int | None = None
-ENDPOINT_MARKERS: list[int] = []
-MIDPOINT_MARKER: int | None = None
+# Hover feedback helpers
+HOVERED_LINE: int | None = None
+
+# Drag helpers
+DRAG_START_POS: Tuple[float, float] | None = None
+DRAG_LINE_ORIGINAL: tuple[tuple[float, float], tuple[float, float]] | None = None
+
+# UI label helper
+CURRENT_SELECTION: str = "None"
 
 
 def toggle_piping_mode(sender, app_data):
@@ -37,6 +43,7 @@ def toggle_piping_mode(sender, app_data):
     global PIPING_MODE
     PIPING_MODE = app_data
     print(f"Piping mode {'enabled' if PIPING_MODE else 'disabled'}")
+    update_info_label()
 
 
 def toggle_snap(sender, app_data):
@@ -44,6 +51,7 @@ def toggle_snap(sender, app_data):
     global SNAP_ENABLED
     SNAP_ENABLED = app_data
     print(f"Snap {'enabled' if SNAP_ENABLED else 'disabled'}")
+    update_info_label()
 
 # ---------------------------------------------------------------------------
 # Interactivity helpers
@@ -56,10 +64,19 @@ interactable_items: dict[int, object] = {}
 """Mapping of draw tags to their backing data objects."""
 
 
+def update_info_label() -> None:
+    """Update the state label on the canvas."""
+    mode = "Piping" if PIPING_MODE else "Select"
+    snap = "On" if SNAP_ENABLED else "Off"
+    text = f"Mode: {mode} | Snap: {snap} | Selection: {CURRENT_SELECTION}"
+    if dpg.does_item_exist("info_label"):
+        dpg.configure_item("info_label", text=text)
+
+
 
 def clear_highlight() -> None:
     """Remove the selection highlight if present."""
-    global SELECTED_LINE, ENDPOINT_MARKERS, MIDPOINT_MARKER
+    global SELECTED_LINE, ENDPOINT_MARKERS, MIDPOINT_MARKER, CURRENT_SELECTION
     if dpg.does_item_exist("selection_marker"):
         dpg.delete_item("selection_marker")
     if dpg.does_item_exist("highlighted_line"):
@@ -72,19 +89,25 @@ def clear_highlight() -> None:
         dpg.delete_item(MIDPOINT_MARKER)
     MIDPOINT_MARKER = None
     SELECTED_LINE = None
+    CURRENT_SELECTION = "None"
+    highlight_hover_line(None)
+    update_info_label()
 
 
 def highlight_selection(pos: Tuple[float, float]) -> None:
     """Draw a highlight circle around the given position."""
+    global CURRENT_SELECTION
     clear_highlight()
     dpg.draw_circle(
         center=pos,
         radius=10,
         color=(255, 255, 0, 255),
         thickness=2,
-        parent="drawlist",
+        parent="ui_layer",
         tag="selection_marker",
     )
+    CURRENT_SELECTION = "Component"
+    update_info_label()
 
 
 def register_interactable(tag: int, obj: object) -> None:
@@ -120,22 +143,23 @@ def move_whole_line(line_tag: int, delta: Tuple[float, float]) -> None:
 
 def highlight_line(tag: int) -> None:
     """Highlight a tubing line and show draggable markers."""
-    global SELECTED_LINE, ENDPOINT_MARKERS, MIDPOINT_MARKER
-
+    global SELECTED_LINE, ENDPOINT_MARKERS, MIDPOINT_MARKER, CURRENT_SELECTION
+    
     clear_highlight()
+    highlight_hover_line(None)
     SELECTED_LINE = tag
 
     cfg = dpg.get_item_configuration(tag)
     p1, p2 = cfg["p1"], cfg["p2"]
 
     dpg.draw_line(p1=p1, p2=p2, color=(255, 255, 0), thickness=3,
-                  parent="drawlist", tag="highlighted_line")
+                  parent="ui_layer", tag="highlighted_line")
 
     ENDPOINT_MARKERS = []
     for i, point in enumerate([p1, p2]):
         drag_tag = dpg.draw_circle(center=point, radius=6, color=(0, 255, 255),
-                                   fill=(0, 255, 255), parent="drawlist")
-        dpg.set_item_callback(drag_tag, lambda s, a, u=i: on_drag_endpoint(tag, u))
+                                   fill=(0, 255, 255), parent="ui_layer")
+        dpg.set_drag_callback(drag_tag, lambda s, a, u=i: on_drag_endpoint(tag, u))
         ENDPOINT_MARKERS.append(drag_tag)
 
     midpoint = ((p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2)
@@ -144,42 +168,119 @@ def highlight_line(tag: int) -> None:
         pmax=(midpoint[0] + 5, midpoint[1] + 5),
         color=(0, 255, 0),
         fill=(0, 255, 0),
-        parent="drawlist",
+        parent="ui_layer",
     )
-    dpg.set_item_callback(MIDPOINT_MARKER, lambda s, a: on_drag_line(tag))
+    dpg.set_drag_callback(MIDPOINT_MARKER, lambda s, a: on_drag_line(tag))
+    CURRENT_SELECTION = "Line"
+    update_info_label()
+
+
+def highlight_hover_line(tag: int | None) -> None:
+    """Highlight a line under the cursor."""
+    global HOVERED_LINE
+    if HOVERED_LINE == tag:
+        return
+    if dpg.does_item_exist("hover_line"):
+        dpg.delete_item("hover_line")
+    HOVERED_LINE = tag
+    if tag is None:
+        return
+    cfg = dpg.get_item_configuration(tag)
+    p1, p2 = cfg["p1"], cfg["p2"]
+    color = (0, 0, 255) if PIPING_MODE else (255, 255, 0)
+    dpg.draw_line(p1, p2, color=color, thickness=4, parent="ui_layer", tag="hover_line")
 
 
 def find_nearest_snap_target(pos: Tuple[float, float], threshold: float = 15) -> Tuple[float, float] | None:
     """Return the position of the nearest snap target within the threshold."""
-    for t, obj in interactable_items.items():
+    candidates: list[Tuple[float, float]] = []
+    for _, obj in interactable_items.items():
         if hasattr(obj, "position"):
-            if math.dist(pos, obj.position) <= threshold:
-                return obj.position
-    return None
+            candidates.append(obj.position)
+    # Include endpoints of existing tubing lines
+    for tube in PROJECT.tubings:
+        candidates.append(tube.start)
+        candidates.append(tube.end)
+
+    nearest: Tuple[float, float] | None = None
+    best_dist = threshold
+    for c in candidates:
+        d = math.dist(pos, c)
+        if d <= best_dist:
+            nearest = c
+            best_dist = d
+    return nearest
+
 
 
 def on_drag_endpoint(line_tag: int, endpoint_idx: int) -> None:
     """Drag handler for endpoint markers."""
+    global DRAG_START_POS
     mouse_pos = dpg.get_mouse_pos(local=False)
+    if DRAG_START_POS is None:
+        cfg = dpg.get_item_configuration(line_tag)
+        DRAG_START_POS = cfg["p1"] if endpoint_idx == 0 else cfg["p2"]
+
     if SNAP_ENABLED:
         snap_target = find_nearest_snap_target(mouse_pos)
         new_pos = snap_target if snap_target else mouse_pos
     else:
+        snap_target = None
         new_pos = mouse_pos
 
     move_line_endpoint(line_tag, endpoint_idx, new_pos)
     highlight_line(line_tag)
 
+    color = (0, 255, 0) if snap_target else (255, 165, 0)
+    if ENDPOINT_MARKERS:
+        dpg.configure_item(ENDPOINT_MARKERS[endpoint_idx], color=color, fill=color)
+
+    if dpg.does_item_exist("drag_preview"):
+        dpg.delete_item("drag_preview")
+    dpg.draw_line(DRAG_START_POS, new_pos, color=(200, 200, 200), thickness=1,
+                  parent="ui_layer", tag="drag_preview")
+    if snap_target:
+        if dpg.does_item_exist("snap_effect"):
+            dpg.delete_item("snap_effect")
+        dpg.draw_circle(center=snap_target, radius=8, color=(0, 0, 255),
+                        thickness=2, parent="ui_layer", tag="snap_effect")
+    else:
+        if dpg.does_item_exist("snap_effect"):
+            dpg.delete_item("snap_effect")
+
 
 def on_drag_line(line_tag: int) -> None:
     """Drag handler for the line midpoint marker."""
+    global DRAG_LINE_ORIGINAL
     mouse_pos = dpg.get_mouse_pos(local=False)
     cfg = dpg.get_item_configuration(line_tag)
     p1, p2 = cfg["p1"], cfg["p2"]
     midpoint = ((p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2)
+    if DRAG_LINE_ORIGINAL is None:
+        DRAG_LINE_ORIGINAL = (p1, p2)
     dx, dy = mouse_pos[0] - midpoint[0], mouse_pos[1] - midpoint[1]
     move_whole_line(line_tag, (dx, dy))
     highlight_line(line_tag)
+    if MIDPOINT_MARKER is not None:
+        dpg.configure_item(MIDPOINT_MARKER, color=(255, 165, 0), fill=(255, 165, 0))
+    if dpg.does_item_exist("drag_preview"):
+        dpg.delete_item("drag_preview")
+    dpg.draw_line(DRAG_LINE_ORIGINAL[0], DRAG_LINE_ORIGINAL[1],
+                  color=(200, 200, 200), thickness=1,
+                  parent="ui_layer", tag="drag_preview")
+
+
+def on_mouse_move(sender, app_data):
+    """Highlight tubing when hovering."""
+    if DRAG_START_POS is not None or DRAG_LINE_ORIGINAL is not None:
+        return
+    mouse_pos = dpg.get_mouse_pos(local=False)
+    for tag, obj in interactable_items.items():
+        if isinstance(obj, Tubing):
+            if point_near_segment(mouse_pos, obj.start, obj.end, threshold=6.0):
+                highlight_hover_line(tag)
+                return
+    highlight_hover_line(None)
 
 
 def on_mouse_click(sender, app_data):
@@ -190,6 +291,7 @@ def on_mouse_click(sender, app_data):
     if PIPING_MODE:
         selected_item = None
         clear_highlight()
+        highlight_hover_line(None)
         start_line(sender, app_data)
         return
 
@@ -200,6 +302,7 @@ def on_mouse_click(sender, app_data):
             if math.dist(mouse_pos, pos) <= 10:
                 selected_item = (tag, obj)
                 highlight_selection(pos)
+                highlight_hover_line(None)
                 return
 
     for tag, obj in interactable_items.items():
@@ -207,6 +310,7 @@ def on_mouse_click(sender, app_data):
             if point_near_segment(mouse_pos, obj.start, obj.end, threshold=6.0):
                 selected_item = None
                 highlight_line(tag)
+                highlight_hover_line(None)
                 return
 
 
@@ -241,6 +345,16 @@ def on_mouse_drag(sender, app_data):
 
 def on_mouse_release(sender, app_data):
     """Finish drawing if not interacting with an item."""
+    global DRAG_START_POS, DRAG_LINE_ORIGINAL
+    if DRAG_START_POS is not None or DRAG_LINE_ORIGINAL is not None:
+        if dpg.does_item_exist("drag_preview"):
+            dpg.delete_item("drag_preview")
+        if dpg.does_item_exist("snap_effect"):
+            dpg.delete_item("snap_effect")
+        DRAG_START_POS = None
+        DRAG_LINE_ORIGINAL = None
+        highlight_line(SELECTED_LINE) if SELECTED_LINE is not None else None
+        return
     if selected_item is None:
         finish_line(sender, app_data)
 
@@ -501,6 +615,7 @@ def start_line(sender, app_data):
     selected_item = None
     pos = dpg.get_mouse_pos(local=False)
     CURRENT_LINE = [pos[0], pos[1]]
+    update_info_label()
 
 
 def finish_line(sender, app_data):
@@ -524,6 +639,20 @@ def finish_line(sender, app_data):
 
 
     PROJECT.tubings.append(line)
+    # animate creation
+    steps = 10
+    for i in range(1, steps + 1):
+        t = i / steps
+        inter = (line.start[0] + (line.end[0]-line.start[0]) * t,
+                 line.start[1] + (line.end[1]-line.start[1]) * t)
+        if dpg.does_item_exist("create_anim"):
+            dpg.delete_item("create_anim")
+        dpg.draw_line(line.start, inter, color=(200, 0, 0), thickness=2,
+                      parent="drawlist", tag="create_anim")
+        dpg.render_dearpygui_frame()
+        time.sleep(0.01)
+    if dpg.does_item_exist("create_anim"):
+        dpg.delete_item("create_anim")
     CURRENT_LINE = []
     redraw_canvas()
 
@@ -542,6 +671,8 @@ def add_analyzer():
 
 def redraw_canvas():
     dpg.delete_item("drawlist", children_only=True)
+    if dpg.does_item_exist("ui_layer"):
+        dpg.delete_item("ui_layer", children_only=True)
     interactable_items.clear()
     for idx, line in enumerate(PROJECT.tubings):
         tag = f"tubing_{idx}"
@@ -578,6 +709,7 @@ def redraw_canvas():
 
     if SELECTED_LINE is not None and dpg.does_item_exist(SELECTED_LINE):
         highlight_line(SELECTED_LINE)
+    update_info_label()
 
 
 def main():
@@ -606,11 +738,14 @@ def main():
     with dpg.window(label="Canvas", tag="Canvas", width=600, height=600, pos=(200, 0)):
         with dpg.drawlist(width=580, height=580, tag="drawlist"):
             pass
+        with dpg.drawlist(width=580, height=580, tag="ui_layer"):
+            dpg.draw_text((10, 560), "", tag="info_label")
 
     with dpg.handler_registry():
         dpg.add_mouse_click_handler(button=dpg.mvMouseButton_Left, callback=on_mouse_click)
         dpg.add_mouse_drag_handler(button=dpg.mvMouseButton_Left, callback=on_mouse_drag)
         dpg.add_mouse_release_handler(button=dpg.mvMouseButton_Left, callback=on_mouse_release)
+        dpg.add_mouse_move_handler(callback=on_mouse_move)
         dpg.add_mouse_click_handler(button=dpg.mvMouseButton_Right, callback=on_right_click_down)
         dpg.add_mouse_drag_handler(button=dpg.mvMouseButton_Right, callback=on_right_drag)
         dpg.add_mouse_release_handler(button=dpg.mvMouseButton_Right, callback=on_right_release)
@@ -619,6 +754,7 @@ def main():
     dpg.setup_dearpygui()
     dpg.show_viewport()
     dpg.set_primary_window("Canvas", True)
+    update_info_label()
     while dpg.is_dearpygui_running():
         dpg.render_dearpygui_frame()
     dpg.destroy_context()


### PR DESCRIPTION
## Summary
- add hover highlight and drag previews for tubing segments
- show snap visuals when near snap targets
- expose current mode and selection in canvas label
- animate tubing creation and manage UI layers for cleanup
- merge main updates without conflicts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685b0e9172d48321892cc1060c06f6ae