### PR TITLE
Fix Dear PyGui import

### DIFF
--- a/app/tubing_gui.py
+++ b/app/tubing_gui.py
@@ -12,7 +12,12 @@ import math
 import time
 
 
-from dearpygui import dearpygui as dpg
+try:
+    import dearpygui.dearpygui as dpg
+except ImportError as e:
+    raise ImportError(
+        "Dear PyGui is not installed. Please install it using 'pip install dearpygui'."
+    ) from e
 
 # ---------------------------------------------------------------------------
 # Global state


### PR DESCRIPTION
## Summary
- ensure tubing GUI uses new `import dearpygui.dearpygui` path with helpful error message

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_b_6892568915408321a8e43162405b5490