### PR TITLE
Add ISO/NORSOK standards update checker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,38 @@ The `app.services.agent_tools` module provides two simple utilities:
   ```bash
   python -m app.services.chat_cli
   ```
+
+## Standard Update Checker (ISO/NORSOK)
+
+A simple script is available in `app/services/standards_update_checker.py` for checking
+configured ISO and NORSOK standards against chosen source pages.
+
+Run with default in-code list:
+
+```bash
+python -m app.services.standards_update_checker
+```
+
+Run with your own JSON list:
+
+```bash
+python -m app.services.standards_update_checker --targets-file my_standards.json
+```
+
+Example `my_standards.json`:
+
+```json
+[
+  {
+    "code": "ISO 15156",
+    "source": "ISO Online Browsing Platform",
+    "search_url": "https://www.iso.org/search.html?q=ISO%2015156",
+    "note": "Optional note"
+  },
+  {
+    "code": "NORSOK M-650",
+    "source": "Standard Norge NORSOK catalogue",
+    "search_url": "https://online.standard.no/nb/standarder/norsok/"
+  }
+]
+```

--- a/app/services/standards_update_checker.py
+++ b/app/services/standards_update_checker.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Iterable
+
+import httpx
+
+
+@dataclass(frozen=True)
+class StandardTarget:
+    """A standard and where to look for updates."""
+
+    code: str
+    source: str
+    search_url: str
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class StandardUpdateResult:
+    code: str
+    source: str
+    search_url: str
+    checked_at: str
+    status_code: int
+    found: bool
+    page_title: str | None
+    matched_snippet: str | None
+    note: str = ""
+
+
+DEFAULT_TARGETS: list[StandardTarget] = [
+    StandardTarget(
+        code="ISO 15156",
+        source="ISO Online Browsing Platform",
+        search_url="https://www.iso.org/search.html?q=ISO%2015156",
+        note="Material standards for H2S service.",
+    ),
+    StandardTarget(
+        code="NORSOK M-650",
+        source="Standard Norge NORSOK catalogue",
+        search_url="https://online.standard.no/nb/standarder/norsok/",
+        note="Qualification of manufacturers.",
+    ),
+]
+
+
+class StandardsUpdateChecker:
+    """Check configured sources for visible mentions of standards."""
+
+    def __init__(self, timeout: float = 15.0) -> None:
+        self.timeout = timeout
+
+    def check_targets(self, targets: Iterable[StandardTarget]) -> list[StandardUpdateResult]:
+        with httpx.Client(timeout=self.timeout, follow_redirects=True) as client:
+            return [self._check_one(client, target) for target in targets]
+
+    def _check_one(self, client: httpx.Client, target: StandardTarget) -> StandardUpdateResult:
+        checked_at = datetime.now(UTC).isoformat()
+
+        try:
+            response = client.get(target.search_url)
+            response.raise_for_status()
+            html = response.text
+            found = target.code.lower() in html.lower()
+            title_match = re.search(r"<title[^>]*>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
+            page_title = re.sub(r"\s+", " ", title_match.group(1)).strip() if title_match else None
+            snippet = _extract_match_snippet(html, target.code) if found else None
+
+            return StandardUpdateResult(
+                code=target.code,
+                source=target.source,
+                search_url=target.search_url,
+                checked_at=checked_at,
+                status_code=response.status_code,
+                found=found,
+                page_title=page_title,
+                matched_snippet=snippet,
+                note=target.note,
+            )
+        except httpx.HTTPError as exc:
+            return StandardUpdateResult(
+                code=target.code,
+                source=target.source,
+                search_url=target.search_url,
+                checked_at=checked_at,
+                status_code=0,
+                found=False,
+                page_title=None,
+                matched_snippet=f"Feil ved henting: {exc}",
+                note=target.note,
+            )
+
+
+def _extract_match_snippet(html: str, query: str, radius: int = 70) -> str | None:
+    match = re.search(re.escape(query), html, flags=re.IGNORECASE)
+    if not match:
+        return None
+
+    start = max(match.start() - radius, 0)
+    end = min(match.end() + radius, len(html))
+    raw = html[start:end]
+    cleaned = re.sub(r"<[^>]+>", " ", raw)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned or None
+
+
+def load_targets_from_file(path: str) -> list[StandardTarget]:
+    with open(path, "r", encoding="utf-8") as file:
+        data = json.load(file)
+
+    targets: list[StandardTarget] = []
+    for item in data:
+        targets.append(
+            StandardTarget(
+                code=item["code"],
+                source=item["source"],
+                search_url=item["search_url"],
+                note=item.get("note", ""),
+            )
+        )
+    return targets
+
+
+def format_text_report(results: list[StandardUpdateResult]) -> str:
+    lines = []
+    for result in results:
+        status = "FUNNET" if result.found else "IKKE FUNNET"
+        lines.append(
+            f"- {result.code} ({result.source}) -> {status}, HTTP {result.status_code}, sjekket {result.checked_at}"
+        )
+        if result.page_title:
+            lines.append(f"  Tittel: {result.page_title}")
+        if result.matched_snippet:
+            lines.append(f"  Utdrag: {result.matched_snippet}")
+        if result.note:
+            lines.append(f"  Merknad: {result.note}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Søk etter oppdateringer/treff på ISO- og NORSOK-standarder. "
+            "Legg inn egen liste via JSON-fil ved behov."
+        )
+    )
+    parser.add_argument(
+        "--targets-file",
+        help="JSON-fil med liste av standarder og søke-URLer. Hvis utelatt brukes standardliste i programmet.",
+    )
+    parser.add_argument("--json", action="store_true", help="Skriv resultat som JSON i stedet for tekst.")
+    args = parser.parse_args()
+
+    targets = load_targets_from_file(args.targets_file) if args.targets_file else DEFAULT_TARGETS
+    checker = StandardsUpdateChecker()
+    results = checker.check_targets(targets)
+
+    if args.json:
+        print(json.dumps([asdict(result) for result in results], ensure_ascii=False, indent=2))
+    else:
+        print(format_text_report(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_standards_update_checker.py
+++ b/tests/test_standards_update_checker.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+import httpx
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.services.standards_update_checker import (  # noqa: E402
+    StandardTarget,
+    StandardsUpdateChecker,
+    format_text_report,
+)
+
+
+def test_check_targets_detects_standard_name():
+    html = "<html><title>ISO Search</title><body>Latest release for ISO 15156 part 1.</body></html>"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=html)
+
+    transport = httpx.MockTransport(handler)
+    target = StandardTarget(code="ISO 15156", source="ISO", search_url="https://example.test/iso")
+
+    with httpx.Client(transport=transport) as client:
+        checker = StandardsUpdateChecker()
+        result = checker._check_one(client, target)
+
+    assert result.found is True
+    assert result.page_title == "ISO Search"
+    assert "ISO 15156" in (result.matched_snippet or "")
+
+
+def test_format_text_report_includes_status():
+    html = "<html><title>NORSOK</title><body>No relevant data here.</body></html>"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=html)
+
+    transport = httpx.MockTransport(handler)
+    target = StandardTarget(code="NORSOK M-650", source="NORSOK", search_url="https://example.test/norsok")
+
+    with httpx.Client(transport=transport) as client:
+        checker = StandardsUpdateChecker()
+        result = checker._check_one(client, target)
+
+    report = format_text_report([result])
+    assert "IKKE FUNNET" in report
+    assert "HTTP 200" in report


### PR DESCRIPTION
### Motivation

- Gi et enkelt CLI-verktøy for å finne potensielle oppdateringer eller treff på ISO- og NORSOK-standarder ved å søke i angitte nettsider.
- Gjøre det enkelt å bytte mellom en innebygd mål-liste og en brukerdefinert JSON-liste med standarder og søke-URLer.
- Gi en kort, lesbar rapport (tekst eller JSON) med HTTP-status, sidetittel og utdrag ved treff.

### Description

- Lagt til ny modul `app/services/standards_update_checker.py` som definerer `StandardTarget`, `StandardUpdateResult` og `StandardsUpdateChecker` for å sjekke mål-URLer med `httpx`.
- Implementert HTML-tittel-ekstraksjon og et snippet-uttrekk rundt funnet standardkode med `_extract_match_snippet` for kontekst i rapporten.
- Støtte for å laste mål fra en JSON-fil via `load_targets_from_file` og CLI med `--targets-file` og `--json` flagg i `main()`.
- Opprettet tester `tests/test_standards_update_checker.py` som bruker `httpx.MockTransport` for å validere treffdeteksjon og rapportformat uten nettverkstrafikk, og oppdatert `README.md` med brukseksempler og JSON-mal.

### Testing

- Kjørte `pytest -q tests/test_standards_update_checker.py` mot de nye testene som bruker `httpx.MockTransport` for isolert validering.
- Testkjøringen stoppet i dette miljøet med `ModuleNotFoundError: No module named 'httpx'`, så de automatiserte testene kunne ikke fullføres her (legg til `httpx` i testmiljøet for å kjøre dem).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d8a3a91114832183deaaccdeaed3b4)